### PR TITLE
Annotation processor options from 'compilerArguments' 

### DIFF
--- a/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/Messages.java
+++ b/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/Messages.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Red Hat, Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.jboss.tools.maven.apt.internal;
+
+import org.eclipse.osgi.util.NLS;
+
+
+/**
+ * Messages
+ *
+ * @author patrick
+ */
+public class Messages extends NLS {
+  private static final String BUNDLE_NAME = "org.jboss.tools.maven.apt.internal.messages"; //$NON-NLS-1$
+
+  public static String ProjectUtils_error_invalid_option_name;
+  static {
+    // initialize resource bundle
+    NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+  }
+
+  private Messages() {
+  }
+}

--- a/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/compiler/MavenCompilerAptProjectConfigurator.java
+++ b/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/compiler/MavenCompilerAptProjectConfigurator.java
@@ -24,9 +24,9 @@ public class MavenCompilerAptProjectConfigurator extends AbstractAptProjectConfi
     Assert.isNotNull(mode, "AnnotationProcessingMode can not be null");
     switch(mode) {
       case jdt_apt:
-        return new MavenCompilerJdtAptDelegate();
+        return new MavenCompilerJdtAptDelegate(markerManager);
       case maven_execution:
-        return new MavenCompilerExecutionDelegate();
+        return new MavenCompilerExecutionDelegate(markerManager);
       case disabled:
       default:
     }

--- a/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/compiler/MavenCompilerExecutionDelegate.java
+++ b/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/compiler/MavenCompilerExecutionDelegate.java
@@ -18,6 +18,7 @@ import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.plugin.MojoExecution;
 
+import org.eclipse.m2e.core.internal.markers.IMavenMarkerManager;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
 
 /**
@@ -26,6 +27,10 @@ import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
  * @author Fred Bricon
  */
 public class MavenCompilerExecutionDelegate extends MavenCompilerJdtAptDelegate {
+
+  public MavenCompilerExecutionDelegate(IMavenMarkerManager markerManager) {
+    super(markerManager);
+  }
 
   private static final VersionRange VALID_COMPILER_PLUGIN_RANGE;
   

--- a/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/messages.properties
+++ b/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/messages.properties
@@ -1,0 +1,1 @@
+ProjectUtils_error_invalid_option_name="{0}" is not a valid name for an annotation-processor option

--- a/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/utils/ProjectUtils.java
+++ b/org.jboss.tools.maven.apt.core/src/org/jboss/tools/maven/apt/internal/utils/ProjectUtils.java
@@ -78,7 +78,72 @@ public class ProjectUtils {
     return ret;
   }
   
+  /**
+   * Extract Annotation Processor options from a compiler-argument map
+   */
+  public static Map<String, String> extractProcessorOptions(Map<String, String> compilerArguments) {
+    if (compilerArguments == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> ret = new HashMap<String, String>();
+    
+    for(Map.Entry<String, String> argument : compilerArguments.entrySet()) {
+      String key = argument.getKey();
+      String value = argument.getValue();
+      
+      if (key.startsWith("A")) {
+        if (value != null && value.length() > 0) {
+          ret.put(key.substring(1), value);
+        } else {
+          ret.put(key.substring(1), null);
+        }
+      }
+    }
+    
+    return ret;
+  }
 
+  /**
+   * Validates that the name of a processor option conforms to the grammar defined by
+   * <code>javax.annotation.processing.Processor.getSupportedOptions()</code>.
+   * 
+   * @param optionName
+   * 
+   * @return 
+   *    <code>true</code> if the name conforms to the grammar, 
+   *    <code>false</code> if not.
+   */
+  public static boolean isValidOptionName(String optionName) {
+    if (optionName == null) {
+      return false;
+    }
+    
+    boolean startExpected = true;
+    int codePoint;
+    
+    for (int i=0; i<optionName.length(); i += Character.charCount(codePoint)) {
+      codePoint = optionName.codePointAt(i);
+      
+      if (startExpected) {
+        if (!Character.isJavaIdentifierStart(codePoint)) {
+          return false;
+        }
+        
+        startExpected = false;
+        
+      } else {
+        if (codePoint == '.') {
+          startExpected = true;
+          
+        } else if (!Character.isJavaIdentifierPart(codePoint)) {
+          return false;
+        }        
+      }
+    }
+    
+    return !startExpected;
+  }
+  
   /**
    * Converts the specified relative or absolute {@link File} to a {@link File} that is relative to the base directory
    * of the specified {@link IProject}.

--- a/org.jboss.tools.maven.apt.tests/projects/argumentMap/pom.xml
+++ b/org.jboss.tools.maven.apt.tests/projects/argumentMap/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>argumentMap</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+					<compilerArgument>-AaddGeneratedAnnotation=true</compilerArgument>
+					<compilerArguments>
+						<AaddGeneratedAnnotation>false</AaddGeneratedAnnotation>
+						<AaddGenerationDate>true</AaddGenerationDate>
+						<Aflag></Aflag>
+					</compilerArguments>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.hibernate</groupId>
+						<artifactId>hibernate-jpamodelgen</artifactId>
+						<version>1.1.1.Final</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>org.hibernate.javax.persistence</groupId>
+			<artifactId>hibernate-jpa-2.0-api</artifactId>
+			<version>1.0.0.Final</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/org.jboss.tools.maven.apt.tests/projects/argumentMap/src/main/java/foo/bar/Dummy.java
+++ b/org.jboss.tools.maven.apt.tests/projects/argumentMap/src/main/java/foo/bar/Dummy.java
@@ -1,0 +1,18 @@
+package foo.bar;
+
+import javax.persistence.Entity;
+
+@Entity
+public class Dummy {
+	
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+}

--- a/org.jboss.tools.maven.apt.tests/projects/argumentMap/src/main/java/foo/bar/DummyStuff.java
+++ b/org.jboss.tools.maven.apt.tests/projects/argumentMap/src/main/java/foo/bar/DummyStuff.java
@@ -1,0 +1,8 @@
+package foo.bar;
+
+public class DummyStuff {
+
+	public void nonSense() {
+		System.err.println(Dummy_.name);
+	}
+}

--- a/org.jboss.tools.maven.apt.tests/src/org/jboss/tools/maven/apt/tests/M2eAptProjectconfiguratorTest.java
+++ b/org.jboss.tools.maven.apt.tests/src/org/jboss/tools/maven/apt/tests/M2eAptProjectconfiguratorTest.java
@@ -66,6 +66,14 @@ public class M2eAptProjectconfiguratorTest extends AbstractMavenProjectTestCase 
 		testAnnotationProcessorArguments("p7", expectedOptions);
 	}
 	
+	public void testAnnotationProcessorArgumentsMap() throws Exception {
+		Map<String, String> expectedOptions = new HashMap<String, String>(2);
+		expectedOptions.put("addGenerationDate", "true");
+		// this option is false in <compilerArguments> but is overriden by <compilerArgument>
+		expectedOptions.put("addGeneratedAnnotation", "true");
+		expectedOptions.put("flag", null);
+		testAnnotationProcessorArguments("argumentMap", expectedOptions);
+	}
 
 	public void testNoAnnotationProcessor() throws Exception {
 		IProject p = importProject("projects/p0/pom.xml");
@@ -223,6 +231,9 @@ public class M2eAptProjectconfiguratorTest extends AbstractMavenProjectTestCase 
 		Map<String, String> options = AptConfig.getProcessorOptions(javaProject);
 		for (Map.Entry<String, String> option : expectedOptions.entrySet()) {
 			assertEquals(option.getValue(), options.get(option.getKey()));
+			if (option.getValue() == null) {
+				assertTrue(options.containsKey(option.getKey()));
+			}
 		}
 	}
 	


### PR DESCRIPTION
[MCOMPILER-135](http://jira.codehaus.org/browse/MCOMPILER-135) adds support for annotation processor options via the 'compilerArguments' map. This changeset adds support for this to m2e-apt.

In addition invalid names for annotation-processor options are reported as errors.
